### PR TITLE
Add options to allow send `coupon_ids` to checkout

### DIFF
--- a/lib/chargebeex/hosted_pages.ex
+++ b/lib/chargebeex/hosted_pages.ex
@@ -14,6 +14,15 @@ defmodule Chargebeex.HostedPages do
                 plan_id :: String.t(),
                 customer_id :: String.t(),
                 email :: String.t(),
+                locale :: String.t(),
+                opts :: Checkout.optional_fields()
+              ) ::
+                {:error, any} | {:ok, map()}
+
+    @callback create_checkout(
+                plan_id :: String.t(),
+                customer_id :: String.t(),
+                email :: String.t(),
                 locale :: String.t()
               ) ::
                 {:error, any} | {:ok, map()}
@@ -22,5 +31,5 @@ defmodule Chargebeex.HostedPages do
   @behaviour __MODULE__.Behaviour
 
   @impl __MODULE__.Behaviour
-  defdelegate create_checkout(plan_id, customer_id, email, locale), to: Checkout
+  defdelegate create_checkout(plan_id, customer_id, email, locale, opts \\ []), to: Checkout
 end

--- a/test/chargebeex/hosted_pages_test.exs
+++ b/test/chargebeex/hosted_pages_test.exs
@@ -33,10 +33,10 @@ defmodule Chargebeex.HostedPageCheckoutTest do
       Mox.expect(Tesla.MockAdapter, :call, fn %Tesla.Env{body: body, method: method}, _opts ->
         assert method == :post
 
-        encoded_customer_email = URI.encode_www_form(email)
+        decoded_body = URI.decode_www_form(body)
 
-        assert body ==
-                 "customer%5Bemail%5D=#{encoded_customer_email}&customer%5Bid%5D=#{id}&customer%5Blocale%5D=#{locale}&subscription%5Bplan_id%5D=#{plan_id}"
+        assert decoded_body ==
+                 "customer[email]=fake_email&customer[id]=23&customer[locale]=cat&subscription[plan_id]=my-plan&coupon_ids[0]=23&coupon_ids[1]=5"
 
         {:ok,
          %Tesla.Env{
@@ -48,7 +48,7 @@ defmodule Chargebeex.HostedPageCheckoutTest do
       end)
 
       assert {:ok, ^chargebee_checkout_response} =
-               HostedPages.create_checkout(plan_id, id, email, locale)
+               HostedPages.create_checkout(plan_id, id, email, locale, coupon_ids: ["23", "5"])
     end
   end
 

--- a/test/chargebeex/hosted_pages_test.exs
+++ b/test/chargebeex/hosted_pages_test.exs
@@ -11,7 +11,7 @@ defmodule Chargebeex.HostedPageCheckoutTest do
   describe "create_checkout/2" do
     setup [:customer]
 
-    test "sends correct params to Chargebee", %{
+    test "sends optional params to Chargebee", %{
       customer: %{id: id, email: email, locale: locale},
       plan_id: plan_id
     } do
@@ -49,6 +49,46 @@ defmodule Chargebeex.HostedPageCheckoutTest do
 
       assert {:ok, ^chargebee_checkout_response} =
                HostedPages.create_checkout(plan_id, id, email, locale, coupon_ids: ["23", "5"])
+    end
+
+    test "sends correct params to Chargebee", %{
+      customer: %{id: id, email: email, locale: locale},
+      plan_id: plan_id
+    } do
+      chargebee_checkout_response = %{
+        "hosted_page" => %{
+          "created_at" => 1_644_940_689,
+          "embed" => false,
+          "expires_at" => 1_644_951_489,
+          "id" => "xTDWYMWSePGDjypcdagkkdgQdIkac3DTk",
+          "object" => "hosted_page",
+          "resource_version" => 1_644_940_689_904,
+          "state" => "created",
+          "type" => "checkout_new",
+          "updated_at" => 1_644_940_689,
+          "url" => "/pages/v3/xTDWYMWSePGDjypcdagkkdgQdIkac3DTk/"
+        }
+      }
+
+      Mox.expect(Tesla.MockAdapter, :call, fn %Tesla.Env{body: body, method: method}, _opts ->
+        assert method == :post
+
+        decoded_body = URI.decode_www_form(body)
+
+        assert decoded_body ==
+                 "customer[email]=fake_email&customer[id]=23&customer[locale]=cat&subscription[plan_id]=my-plan"
+
+        {:ok,
+         %Tesla.Env{
+           body: chargebee_checkout_response,
+           method: :post,
+           status: 200,
+           url: "/hosted_pages/checkout_new"
+         }}
+      end)
+
+      assert {:ok, ^chargebee_checkout_response} =
+               HostedPages.create_checkout(plan_id, id, email, locale)
     end
   end
 


### PR DESCRIPTION
<!-- All sections must be filled unless they don't apply  -->

Add option to send `coupon_ids` to checkout hosted pages ([Chargebee docs](https://apidocs.chargebee.com/docs/api/hosted_pages?prod_cat_ver=1&lang=curl#checkout_new_subscription_coupon_ids))
