### PR TITLE
Expose Portal Session creation through defdelegate

### DIFF
--- a/lib/chargebeex/portal_sessions.ex
+++ b/lib/chargebeex/portal_sessions.ex
@@ -1,0 +1,21 @@
+defmodule Chargebeex.PortalSessions do
+  @moduledoc """
+  This module provides the functions  for [Chargebee portal sessions
+  ](https://apidocs.chargebee.com/docs/api/portal_sessions?prod_cat_ver=1&lang=cur).
+  """
+  require Logger
+
+  alias Chargebeex.PortalSessions.Create
+
+  defmodule Behaviour do
+    @moduledoc false
+
+    @callback create(customer_id :: String.t()) ::
+                {:error, any} | {:ok, map()}
+  end
+
+  @behaviour __MODULE__.Behaviour
+
+  @impl __MODULE__.Behaviour
+  defdelegate create(customer_id), to: Create
+end

--- a/test/chargebeex/portal_sessions/create_test.exs
+++ b/test/chargebeex/portal_sessions/create_test.exs
@@ -1,7 +1,11 @@
 defmodule Chargebeex.PortalSessions.CreateTest do
   use ExUnit.Case, async: true
 
+  import Mox
+
   alias Chargebeex.PortalSessions.Create
+
+  setup [:verify_on_exit!]
 
   describe "create/1" do
     test "returns a map with the response" do


### PR DESCRIPTION
<!-- All sections must be filled unless they don't apply  -->

## Motivation

In previous PR we missed exposing PortalSession.Create through the main PortalSession module as we do for the other API calls. 

## Technical details

- Create a new module PortalSession 

## To-do


## Screenshots

## QA (How to test)

### Setup requirements

<!-- Dependencies on other apps, data setup... -->

### Test cases

N/A

## GIF

N/A

## Checklist

- [X] My changes are tested
